### PR TITLE
Remove ~{sep } call on File type

### DIFF
--- a/assembly/wdl/workflows/evaluateHumanAssembly.wdl
+++ b/assembly/wdl/workflows/evaluateHumanAssembly.wdl
@@ -412,7 +412,7 @@ task createAssemblyStatistics {
     }
 
     command <<<
-        R --no-save --args ~{sep=" " mashmap} <<Rscript
+        R --no-save --args ~{mashmap} <<Rscript
         args <- commandArgs(trailingOnly = TRUE)
         filename<-args[1]
 


### PR DESCRIPTION
Calling `~{sep=" " mashmap}` on a `File` instead of `Array[File]` seems to trip up miniWDL but not Cromwell.